### PR TITLE
Fix: also support the 'new_pullrequest' trigger

### DIFF
--- a/.github/workflows/new_openttd_release.yml
+++ b/.github/workflows/new_openttd_release.yml
@@ -5,6 +5,7 @@ on:
     types:
     - new_tag
     - new_master
+    - new_pullrequest
 
 jobs:
   new_release:


### PR DESCRIPTION
This should only rebuild the website, as it contains links there.