### PR TITLE
Add: [CDN] code and config to generate required files for CDN

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+max-line-length = 120
+inline-quotes = double
+
+# We use 'black' for coding style; these next two warnings are not PEP-8
+# compliant.
+# E231 is a bug in 'black', see https://github.com/psf/black/issues/1202
+ignore = E203, E231, W503

--- a/.github/workflows/new_openttd_release.yml
+++ b/.github/workflows/new_openttd_release.yml
@@ -7,31 +7,42 @@ on:
     - new_master
     - new_pullrequest
 
+# client_payload should contain:
+#  - version: the version of the new release, e.g.: 20200101-master-g12345
+#  - folder: the folder in which the release is located openttd-nightlies/2020
+
 jobs:
   new_release:
     name: New OpenTTD release
     runs-on: ubuntu-latest
 
     steps:
-    - name: Trigger website (staging)
-      uses: peter-evans/repository-dispatch@v1
-      with:
-        token: ${{ secrets.DEPLOYMENT_TOKEN }}
-        repository: OpenTTD/website
-        event-type: publish_master
+    - name: Sanity check
+      run: |
+        set -x
 
-    - name: Trigger website (Production)
+        if [ -z "${{ github.event.client_payload.version }}" ]; then
+          echo "::error::version in client_payload is not set"
+          exit 1
+        fi
+        if [ -z "${{ github.event.client_payload.folder }}" ]; then
+          echo "::error::folder in client_payload is not set"
+          exit 1
+        fi
+
+    - name: Trigger 'update CDN'
       uses: peter-evans/repository-dispatch@v1
       with:
         token: ${{ secrets.DEPLOYMENT_TOKEN }}
-        repository: OpenTTD/website
-        event-type: publish_latest_tag
+        repository: OpenTTD/workflows
+        event-type: update_cdn
+        client-payload: '{"version": "${{ github.event.client_payload.version }}", "folder": "${{ github.event.client_payload.folder }}"}'
 
     - if: github.event.action == 'new_master'
-      name: Trigger docs
+      name: Trigger 'publish docs'
       uses: peter-evans/repository-dispatch@v1
       with:
         token: ${{ secrets.DEPLOYMENT_TOKEN }}
         repository: OpenTTD/workflows
         event-type: publish_docs
-        client-payload: '{"version": "${{ github.event.client_payload.version }}"}'
+        client-payload: '{"version": "${{ github.event.client_payload.version }}", "folder": "${{ github.event.client_payload.folder }}"}'

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -5,12 +5,37 @@ on:
     types:
     - publish_docs
 
+# client_payload should contain:
+#  - version: the version of the new release, e.g.: 20200101-master-g12345
+#  - folder: the folder in which the release is located openttd-nightlies/2020
+
 jobs:
   publish_docs:
     name: Publish docs
     runs-on: ubuntu-latest
 
     steps:
+    - name: Sanity check
+      run: |
+        set -x
+
+        if [ -z "${{ github.event.client_payload.version }}" ]; then
+          echo "::error::version in client_payload is not set"
+          exit 1
+        fi
+        if [ -z "${{ github.event.client_payload.folder }}" ]; then
+          echo "::error::folder in client_payload is not set"
+          exit 1
+        fi
+        if [ -z "${{ secrets.DOCS_S3_BUCKET }}" ]; then
+          echo "::error::secret DOCS_S3_BUCKET is not set"
+          exit 1
+        fi
+        if [ -z "${{ secrets.DOCS_CF_DISTRIBUTION_ID }}" ]; then
+          echo "::error::secret DOCS_CF_DISTRIBUTION_ID is not set"
+          exit 1
+        fi
+
     - name: Checkout
       uses: actions/checkout@v2
 
@@ -19,45 +44,33 @@ jobs:
         set -x
 
         VERSION=${{ github.event.client_payload.version }}
-
-        if [ -z "${VERSION}" ]; then
-          echo "::error::version in client_payload is not set"
-          exit 1
-        fi
-        if [ -z "${{ secrets.S3_BUCKET }}" ]; then
-          echo "::error::secret S3_BUCKET is not set"
-          exit 1
-        fi
-        if [ -z "${{ secrets.CF_DISTRIBUTION_ID }}" ]; then
-          echo "::error::secret CF_DISTRIBUTION_ID is not set"
-          exit 1
-        fi
+        FOLDER=${{ github.event.client_payload.folder }}
 
         # Fetch and extract the docs
-        curl --fail -s -L -o docs-ai.tar.xz https://proxy.binaries.openttd.org/openttd-nightlies/${VERSION}/openttd-${VERSION}-docs-ai.tar.xz
-        curl --fail -s -L -o docs-gs.tar.xz https://proxy.binaries.openttd.org/openttd-nightlies/${VERSION}/openttd-${VERSION}-docs-gs.tar.xz
-        curl --fail -s -L -o docs.tar.xz https://proxy.binaries.openttd.org/openttd-nightlies/${VERSION}/openttd-${VERSION}-docs.tar.xz
+        curl --fail -s -L -o docs-ai.tar.xz https://cdn.openttd.org/${FOLDER}/${VERSION}/openttd-${VERSION}-docs-ai.tar.xz
+        curl --fail -s -L -o docs-gs.tar.xz https://cdn.openttd.org/${FOLDER}/${VERSION}/openttd-${VERSION}-docs-gs.tar.xz
+        curl --fail -s -L -o docs.tar.xz https://cdn.openttd.org/${FOLDER}/${VERSION}/openttd-${VERSION}-docs.tar.xz
         tar xf docs-ai.tar.xz
         tar xf docs-gs.tar.xz
         tar xf docs.tar.xz
 
         # Sync all the new/modified files
-        aws s3 sync --only-show-errors docs/root/ s3://${{ secrets.S3_BUCKET }}/
-        aws s3 sync --only-show-errors docs/errors/ s3://${{ secrets.S3_BUCKET }}/errors/
-        aws s3 sync --only-show-errors openttd-${VERSION}-docs-ai/html/ s3://${{ secrets.S3_BUCKET }}/ai-api/
-        aws s3 sync --only-show-errors openttd-${VERSION}-docs-gs/html/ s3://${{ secrets.S3_BUCKET }}/gs-api/
-        aws s3 sync --only-show-errors openttd-${VERSION}-docs/html/ s3://${{ secrets.S3_BUCKET }}/source/
+        aws s3 sync --only-show-errors docs/root/ s3://${{ secrets.DOCS_S3_BUCKET }}/
+        aws s3 sync --only-show-errors docs/errors/ s3://${{ secrets.DOCS_S3_BUCKET }}/errors/
+        aws s3 sync --only-show-errors openttd-${VERSION}-docs-ai/html/ s3://${{ secrets.DOCS_S3_BUCKET }}/ai-api/
+        aws s3 sync --only-show-errors openttd-${VERSION}-docs-gs/html/ s3://${{ secrets.DOCS_S3_BUCKET }}/gs-api/
+        aws s3 sync --only-show-errors openttd-${VERSION}-docs/html/ s3://${{ secrets.DOCS_S3_BUCKET }}/source/
 
         # Delete any unknown file; this is a separate step, as 'aws s3 sync'
         # can delete before uploading, which could mean files temporary link
         # to invalid files.
-        aws s3 sync --only-show-errors --delete docs/errors/ s3://${{ secrets.S3_BUCKET }}/errors/
-        aws s3 sync --only-show-errors --delete openttd-${VERSION}-docs-ai/html/ s3://${{ secrets.S3_BUCKET }}/ai-api/
-        aws s3 sync --only-show-errors --delete openttd-${VERSION}-docs-gs/html/ s3://${{ secrets.S3_BUCKET }}/gs-api/
-        aws s3 sync --only-show-errors --delete openttd-${VERSION}-docs/html/ s3://${{ secrets.S3_BUCKET }}/source/
+        aws s3 sync --only-show-errors --delete docs/errors/ s3://${{ secrets.DOCS_S3_BUCKET }}/errors/
+        aws s3 sync --only-show-errors --delete openttd-${VERSION}-docs-ai/html/ s3://${{ secrets.DOCS_S3_BUCKET }}/ai-api/
+        aws s3 sync --only-show-errors --delete openttd-${VERSION}-docs-gs/html/ s3://${{ secrets.DOCS_S3_BUCKET }}/gs-api/
+        aws s3 sync --only-show-errors --delete openttd-${VERSION}-docs/html/ s3://${{ secrets.DOCS_S3_BUCKET }}/source/
 
         # Invalidate the cache of the CloudFront distribution
-        aws cloudfront create-invalidation --distribution-id ${{ secrets.CF_DISTRIBUTION_ID }} --paths "/*"
+        aws cloudfront create-invalidation --distribution-id ${{ secrets.DOCS_CF_DISTRIBUTION_ID }} --paths "/*"
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,35 @@
+name: Testing
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  flake8:
+    name: Flake8
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Flake8
+      uses: TrueBrain/actions-flake8@master
+      with:
+        path: cdn/cdn_generator
+
+  black:
+    name: Black
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Black
+      run: |
+        python -m pip install --upgrade pip
+        pip install black
+        black -l 120 --check cdn/cdn_generator

--- a/.github/workflows/update_cdn.yml
+++ b/.github/workflows/update_cdn.yml
@@ -1,0 +1,86 @@
+name: Update CDN
+
+on:
+  repository_dispatch:
+    types:
+    - update_cdn
+
+# client_payload should contain:
+#  - version: the version of the new release, e.g.: 20200101-master-g12345
+#  - folder: the folder in which the release is located openttd-nightlies/2020
+
+jobs:
+  update_cdn:
+    name: Update CDN
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Sanity check
+      run: |
+        set -x
+
+        if [ -z "${{ github.event.client_payload.version }}" ]; then
+          echo "::error::version in client_payload is not set"
+          exit 1
+        fi
+        if [ -z "${{ github.event.client_payload.folder }}" ]; then
+          echo "::error::folder in client_payload is not set"
+          exit 1
+        fi
+        if [ -z "${{ secrets.CDN_S3_BUCKET }}" ]; then
+          echo "::error::secret CDN_S3_BUCKET is not set"
+          exit 1
+        fi
+        if [ -z "${{ secrets.CDN_CF_DISTRIBUTION_ID }}" ]; then
+          echo "::error::secret CDN_CF_DISTRIBUTION_ID is not set"
+          exit 1
+        fi
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r cdn/requirements.txt
+
+    # By default, mime.types doesn't include one for YAML files. This results
+    # in "binary/octet-stream" as content-type on the CDN, which means
+    # browsers want to download the file instead of showing it inline. By
+    # adding this entry to mime.types, we fix that problem.
+    - name: Fix mimetypes
+      run: |
+        echo "text/vnd.yaml  yaml" | sudo tee -a /etc/mime.types
+
+    - name: Publish CDN files
+      run: |
+        set -x
+
+        cd cdn
+
+        python -m cdn_generator --bucket-id ${{ secrets.CDN_S3_BUCKET }} --new-release ${{ github.event.client_payload.folder }}/${{ github.event.client_payload.version }}
+
+        aws s3 cp --recursive --only-show-errors generated/ s3://${{ secrets.CDN_S3_BUCKET }}/
+        aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_CF_DISTRIBUTION_ID }} --paths "/*"
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    - name: Trigger 'publish website (staging)'
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.DEPLOYMENT_TOKEN }}
+        repository: OpenTTD/website
+        event-type: publish_master
+
+    - name: Trigger 'publish website (Production)'
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.DEPLOYMENT_TOKEN }}
+        repository: OpenTTD/website
+        event-type: publish_latest_tag

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+cdn/generated

--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ This repository runs a few workflows that don't belong to a repository we have.
 
 - [New OpenTTD Release](.github/workflows/new_openttd_release.yml): workflow that is triggered when a new OpenTTD binary is produced
 - [Publish Docs](.github/workflows/publish_docs.yml): publishes the HTML docs to https://docs.openttd.org/ based on an openttd-nightly version.
+- [Update CDN](.github/workflows/update_cdn.yml): updates the [CDN](https://cdn.openttd.org) with required files like index.html, manifest.yaml, etc.

--- a/cdn/README.md
+++ b/cdn/README.md
@@ -1,0 +1,58 @@
+# Content Delivery Network
+
+OpenTTD publishes all the binaries produced to a CDN.
+This CDN is hosted by AWS CloudFront, which fetches the files from a private AWS S3.
+There are a various amount of files on the CDN to help with automation and human readability.
+
+## index.html
+
+AWS S3 has no ability to do directory listing.
+From experience, OpenTTD has found out that a CDN without being able to browse files, often leads to frustration by its end users.
+As such, part of the `cdn-generator` is to create `index.html` files in every folder.
+It does a few tricks, like sorting by version and like putting the newest version on top, to make it more useful.
+By publishing this `index.html` on the CDN, it feels like there is directory listing enabled.
+It really isn't.
+
+## folders.yaml
+
+Similar to `index.html`, but with only the folders, and in a format that can easily be automated.
+
+## manifest.yaml
+
+Every release has a `manifest.yaml`, which contains all the important parts of the release.
+Automation can use this file to know what file to download, or what size to expect.
+There are also checksum values there to validate a download.
+
+## latest.yaml
+
+For automation, you often want to know: what is the latest release.
+In the root folder and every subfolder there-of, there is a `latest.yaml` indicating exactly this.
+Per category, there are two choices: either it is "releases" or something else.
+In case of the first, there can be a "stable" and "testing" version.
+Otherwise there is always one.
+There are several keys per entry:
+
+- `version`: indicates the latest version.
+- `name`: indicates if it is stable/testing (in case of "releases") or what type this is ("master", "trunk", "nightly", ..).
+- `category`: the category this entry belongs to.
+- `date`: the date when this version was released.
+- `folder`: in which folder thie version can be found, relative to `latest.yaml`.
+
+In the root, all `latest.yaml` from the children are combined together.
+
+## config.yaml
+
+In the root there is a `config.yaml`.
+This tells the `cdn-generator` which folders to index, and how to do this exactly.
+There are several keys per entry:
+
+- `name`: name of the folder to configure.
+- `subfolders`: optional (default: none).
+  - `per-name`: the name of the subfolder is just a name, and the versions are a subfolder of those folders.
+  - `per-year`: the subfolder is split per year.
+- `override-name`: optional (default: use `name`).
+  - `nightly`: force the name to be "nightly".
+  - `in-folder-name`: folder should be named `XXX-NAME-XXX`, and the name is the `NAME` part.
+- `sort`: optional (default: `version`).
+  - `normal`: use "abc" sorting.
+  - `version`: use version sorting: "1.9-alpha1" < "1.9-beta2" < "1.9-RC3" < "1.9" < "1.10".

--- a/cdn/cdn_generator/__main__.py
+++ b/cdn/cdn_generator/__main__.py
@@ -1,0 +1,60 @@
+import click
+import yaml
+
+from cdn_generator.common_files import generate_common_files
+from cdn_generator.helpers import set_bucket_id
+from cdn_generator.latest_yaml import (
+    generate_latest_yaml,
+    write_latest_yaml,
+)
+from cdn_generator.manifest_yaml import generate_manifests
+from cdn_generator.directory_listing import (
+    generate_directory_listing,
+    generate_directory_listing_root,
+)
+
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.option("--bucket-id", help="Id of the S3 Bucket", required=True)
+@click.option("--new-release", help="Folder of the new release")
+def main(bucket_id, new_release):
+    set_bucket_id(bucket_id)
+
+    with open("config.yaml", "r") as f:
+        config_yaml = yaml.safe_load(f.read())
+    config = {folder["name"]: folder for folder in config_yaml["folders"]}
+
+    if new_release and not new_release.endswith("/"):
+        new_release += "/"
+
+    generate_common_files()
+
+    all_versions = []
+    for category, category_config in config.items():
+        skip_write = new_release and not new_release.startswith(f"{category}/")
+
+        # Always calculate the latest versions for every category. This
+        # because there will be a root "latest.yaml", which has to contain
+        # the information of all releases. But only write "latest.yaml" for
+        # folders in the tree of "new_release".
+        category_versions = generate_latest_yaml(category, config=category_config, filter_path=new_release)
+        for item in category_versions:
+            if "folder" in item:
+                item["folder"] = f"{category}/{item['folder']}"
+            else:
+                item["folder"] = category
+        all_versions.extend(category_versions)
+
+        if not skip_write:
+            generate_manifests(category, category_config, filter_path=new_release)
+            generate_directory_listing(category, config=category_config, filter_path=new_release)
+
+    write_latest_yaml("", all_versions)
+    generate_directory_listing_root("", ignore_folders=["static", "errors"])
+
+
+if __name__ == "__main__":
+    main(auto_envvar_prefix="CDN")

--- a/cdn/cdn_generator/common_files.py
+++ b/cdn/cdn_generator/common_files.py
@@ -1,0 +1,22 @@
+import pathlib
+import shutil
+
+
+def generate_common_files():
+    """
+    Copy a bunch of static files into the generated folder.
+
+    This means they are copied to the CDN too on next sync. They are
+    technically not generated, but creating a second flow just for these
+    files doesn't make sense.
+    """
+
+    pathlib.Path("generated").mkdir(parents=True, exist_ok=True)
+    shutil.copyfile("config.yaml", "generated/config.yaml")
+    shutil.copyfile("README.md", "generated/README.md")
+
+    pathlib.Path("generated/errors").mkdir(parents=True, exist_ok=True)
+    shutil.copyfile("errors/404.html", "generated/errors/404.html")
+
+    with open("generated/robots.txt", "w") as f:
+        f.write("\n".join(["User-agent: *", "Disallow: /"]) + "\n")

--- a/cdn/cdn_generator/directory_listing.py
+++ b/cdn/cdn_generator/directory_listing.py
@@ -1,0 +1,114 @@
+import os
+import pathlib
+
+from cdn_generator.helpers import list_folder
+
+
+def _generate_folders_yaml(prefix, folders):
+    if not folders:
+        return
+
+    folders_content = [
+        "folders:",
+    ]
+    for folder in folders:
+        folders_content.append(f"- name: {folder}")
+
+    pathlib.Path(f"generated/{prefix}").mkdir(parents=True, exist_ok=True)
+    with open(f"generated/{prefix}/folders.yaml", "w") as f:
+        f.write("\n".join(folders_content) + "\n")
+
+
+def _generate_index_html(prefix, folders, files):
+    html_content = [
+        "<html>",
+        f"<head><title>Index of /{prefix}</title></head>",
+        '<body bgcolor="white">',
+        f"<h1>Index of /{prefix}</h1>",
+        "<hr>",
+        "<pre>",
+    ]
+
+    if prefix != "/":
+        html_content.append('<a href="../">../</a>')
+
+    for folder in folders:
+        html_content.append(f'<a href="{folder}/">{folder}/</a>')
+
+    for id, size in files.items():
+        # These sums are already in manifest.yaml; there is no need to link to
+        # them directly, as it makes the index file hard to read.
+        if id.endswith((".md5sum", "sha1sum", "sha256sum")):
+            continue
+
+        # Align with spaces; this is done by most httpds too
+        size = " " * (70 - len(id)) + str(size)
+        html_content.append(f'<a href="{id}">{id}</a> {size}')
+
+    html_content.extend(["</pre>", "<hr>", "</body>", "</html>"])
+
+    pathlib.Path(f"generated/{prefix}").mkdir(parents=True, exist_ok=True)
+    with open(f"generated/{prefix}/index.html", "w") as f:
+        f.write("\n".join(html_content) + "\n")
+
+
+def _generate_directory_listing(prefix, files, folders):
+    print(f"Creating directory listing for {prefix} ...")
+
+    # Generate a folders.yaml and latest.yaml
+    _generate_folders_yaml(prefix, folders)
+
+    # It is possible we rendered some files locally; add these to the list too.
+    for f in os.listdir(f"generated/{prefix}"):
+        if os.path.isfile(f"generated/{prefix}/{f}"):
+            files[f] = os.stat(f"generated/{prefix}/{f}").st_size
+    # Hide existing index.html from the index
+    if "index.html" in files:
+        del files["index.html"]
+
+    _generate_index_html(prefix, folders, files)
+
+
+def _generate_directory_listing_single(prefix, is_version_folder, filter_path=None):
+    files, folders = list_folder(prefix, is_version_folder=is_version_folder)
+
+    # Reverse the folders to make sure the latest version is on top (sorting
+    # is already done by list_folder()).
+    folders.reverse()
+    _generate_directory_listing(prefix, files, folders)
+
+    for folder in folders:
+        skip_write = filter_path and not filter_path.startswith(f"{prefix}/{folder}/")
+
+        if not skip_write:
+            files, folders = list_folder(f"{prefix}/{folder}")
+            _generate_directory_listing(f"{prefix}/{folder}", files, folders)
+
+
+def generate_directory_listing(category, config, filter_path=None):
+    is_version_folder = config.get("sort") != "normal"
+
+    if config.get("subfolders") is None:
+        _generate_directory_listing_single(category, is_version_folder, filter_path=filter_path)
+        return
+
+    files, folders = list_folder(category)
+    _generate_directory_listing(category, files, folders)
+
+    for folder in folders:
+        skip_write = filter_path and not filter_path.startswith(f"{category}/{folder}/")
+
+        if not skip_write:
+            _generate_directory_listing_single(f"{category}/{folder}", is_version_folder, filter_path=filter_path)
+
+
+def generate_directory_listing_root(category, ignore_folders):
+    files, folders = list_folder(category)
+
+    # Remove the folders we ignore (this is only supported on root-level)
+    if ignore_folders is not None:
+        for folder in ignore_folders:
+            if folder in folders:
+                folders.remove(folder)
+
+    _generate_directory_listing(category, files, folders)

--- a/cdn/cdn_generator/helpers.py
+++ b/cdn/cdn_generator/helpers.py
@@ -1,0 +1,82 @@
+import boto3
+import sys
+
+from botocore.exceptions import ClientError
+
+from cdn_generator.version_sort import version_sort
+
+BUCKET = None
+
+client = boto3.client("s3")
+
+
+class UnknownOverrideName(Exception):
+    pass
+
+
+def list_folder(prefix, is_version_folder=False):
+    if not prefix.endswith("/"):
+        prefix += "/"
+    if prefix == "/":
+        prefix = ""
+
+    files = {}
+    folders = []
+
+    listing = {
+        "IsTruncated": True,
+    }
+    while listing["IsTruncated"]:
+        kwargs = {}
+        if "NextContinuationToken" in listing:
+            kwargs["ContinuationToken"] = listing["NextContinuationToken"]
+
+        listing = client.list_objects_v2(Bucket=BUCKET, Delimiter="/", Prefix=prefix, **kwargs,)
+
+        if "Contents" in listing:
+            files.update({obj["Key"][len(prefix) :]: obj["Size"] for obj in listing["Contents"]})
+
+        if "CommonPrefixes" in listing:
+            folders.extend([obj["Prefix"][len(prefix) : -1] for obj in listing["CommonPrefixes"]])
+
+    files = {f: files[f] for f in sorted(files.keys(), key=lambda s: s.lower())}
+    if is_version_folder:
+        folders.sort(key=version_sort)
+    else:
+        folders.sort()
+
+    return files, folders
+
+
+def get_content(key):
+    try:
+        content = client.get_object(Bucket=BUCKET, Key=key,)
+    except ClientError:
+        print(f"Tried getting object '{key}'", file=sys.stderr)
+        raise
+    return content["Body"].read().decode().strip()
+
+
+def get_name(folder, config):
+    override_name = config.get("override-name")
+    if override_name is None:
+        # If there is a "-" in the version (which is the folder), it is a
+        # testimg release. Examples: 1.2.3-beta1, 1.2.3-RC2.
+        if "-" in folder:
+            name = "testing"
+        else:
+            name = "stable"
+    elif override_name == "in-folder-name":
+        # These binaries are in the form of YYYYMMDD-NAME-...
+        name = folder.split("-")[1]
+    elif override_name == "nightly":
+        name = "nightly"
+    else:
+        raise UnknownOverrideName(f"Unknown override-name value '{override_name}' for {folder}")
+
+    return name
+
+
+def set_bucket_id(bucket_id):
+    global BUCKET
+    BUCKET = bucket_id

--- a/cdn/cdn_generator/latest_yaml.py
+++ b/cdn/cdn_generator/latest_yaml.py
@@ -1,0 +1,117 @@
+import pathlib
+
+from cdn_generator.helpers import (
+    list_folder,
+    get_content,
+    get_name,
+)
+
+
+def _find_latest_version(prefix, config):
+    is_version_folder = config.get("sort") != "normal"
+    base_category = "-".join(prefix.split("-")[:-1])
+
+    _, folders = list_folder(prefix, is_version_folder=is_version_folder)
+    folders.reverse()
+
+    if not folders:
+        return []
+
+    latest_versions = []
+
+    if is_version_folder:
+        # Find the first folder that is testing ("-RCN", "-betaN")
+        for folder in folders:
+            if "-" in folder:
+                testing = folder
+                break
+        else:
+            testing = None
+
+        # Find the first folder that is stable (so without any postfix)
+        for folder in folders:
+            if "-" not in folder:
+                stable = folder
+                break
+        else:
+            stable = None
+
+        if stable:
+            date_stable = get_content(f"{prefix}/{stable}/released.txt").replace(" ", "T").replace("TUTC", ":00-00:00")
+            latest_versions.append(
+                {"version": stable, "name": "stable", "category": base_category, "date": date_stable,}
+            )
+
+        if testing:
+            date_testing = (
+                get_content(f"{prefix}/{testing}/released.txt").replace(" ", "T").replace("TUTC", ":00-00:00")
+            )
+
+            # There is only a testing if the stable is older
+            if stable and date_stable < date_testing:
+                latest_versions.append(
+                    {"version": testing, "name": "testing", "category": base_category, "date": date_testing,}
+                )
+
+    else:
+        name = get_name(folders[0], config)
+
+        date = get_content(f"{prefix}/{folders[0]}/released.txt").replace(" ", "T").replace("TUTC", ":00-00:00")
+        latest_versions.append(
+            {"version": folders[0], "name": name, "category": base_category, "date": date,}
+        )
+
+    return latest_versions
+
+
+def write_latest_yaml(prefix, latest_versions):
+    latest_content = ["latest:"]
+    for item in latest_versions:
+        latest_content.append(f"- version: {item['version']}")
+        for key, value in item.items():
+            if key == "version":
+                continue
+
+            latest_content.append(f"  {key}: {value}")
+
+    pathlib.Path(f"generated/{prefix}").mkdir(parents=True, exist_ok=True)
+    with open(f"generated/{prefix}/latest.yaml", "w") as f:
+        f.write("\n".join(latest_content) + "\n")
+
+
+def generate_latest_yaml(prefix, config, filter_path=None):
+    print(f"Creating latest.yaml for {prefix} ...")
+
+    skip_write = filter_path and not filter_path.startswith(f"{prefix}/")
+    subfolders = config.get("subfolders")
+
+    if subfolders is None:
+        latest_versions = _find_latest_version(prefix, config)
+    elif subfolders == "per-year":
+        _, folders = list_folder(prefix)
+        # The latest folder should be the latest year
+        latest_versions = _find_latest_version(f"{prefix}/{folders[-1]}", config)
+        for item in latest_versions:
+            item["folder"] = folders[-1]
+    elif subfolders == "per-name":
+        old_subfolders = config["subfolders"]
+        config["subfolders"] = None
+
+        latest_versions = []
+
+        # Generate a latest.yaml per subfolder
+        _, folders = list_folder(prefix)
+        for folder in folders:
+            subfolder_versions = generate_latest_yaml(f"{prefix}/{folder}", config, filter_path=filter_path)
+            for item in subfolder_versions:
+                item["folder"] = folder
+            latest_versions.extend(subfolder_versions)
+
+        config["subfolders"] = old_subfolders
+    else:
+        raise Exception("Unknown subfolders type '{subfolders}'")
+
+    if not skip_write:
+        write_latest_yaml(prefix, latest_versions)
+
+    return latest_versions

--- a/cdn/cdn_generator/manifest_yaml.py
+++ b/cdn/cdn_generator/manifest_yaml.py
@@ -1,0 +1,104 @@
+import os
+import pathlib
+
+from cdn_generator.helpers import (
+    list_folder,
+    get_content,
+    get_name,
+)
+
+# If this is part of the filename, these files are marked as "dev" files
+DEV_IF_FILENAME_CONTAINS = [
+    "docs",
+    "source",
+    "dbg.deb",
+    "pdb.xz",
+]
+
+
+def _generate_manifest(category, folder, files, config):
+    # Don't generate manifest.yaml if it already exists.
+    if os.path.isfile(f"generated/{category}/{folder}/manifest.yaml"):
+        return
+
+    print(f"Creating manifest for {category} {folder} ...")
+
+    name = get_name(folder, config)
+    base_category = "-".join(category.split("-")[:-1])
+    base = f"{base_category}-{folder}-"
+
+    prefix = f"{category}/{folder}"
+    manifest = []
+    manifest_files = []
+    manifest_dev_files = []
+
+    for id, size in files.items():
+        if id.endswith((".html", ".md", ".txt", ".yaml", ".md5sum", ".sha1sum", ".sha256sum")):
+            continue
+
+        md5sum = get_content(f"{prefix}/{id}.md5sum").split(" ")[0]
+        sha1sum = get_content(f"{prefix}/{id}.sha1sum").split(" ")[0]
+        sha256sum = get_content(f"{prefix}/{id}.sha256sum").split(" ")[0]
+
+        file_content = [
+            f"- id: {id}",
+            f"  size: {size}",
+            f"  md5sum: {md5sum}",
+            f"  sha1sum: {sha1sum}",
+            f"  sha256sum: {sha256sum}",
+        ]
+
+        if not id.startswith(base):
+            raise Exception(f"Filename '{id}' doesn't start with base '{base}'")
+
+        if any([True for check in DEV_IF_FILENAME_CONTAINS if check in id]):
+            manifest_dev_files.extend(file_content)
+        else:
+            manifest_files.extend(file_content)
+
+    date = get_content(f"{prefix}/released.txt").replace(" ", "T").replace("TUTC", ":00-00:00")
+
+    manifest.extend(
+        [
+            f"name: {name}",
+            f"category: {base_category}",
+            f"version: {folder}",
+            f"date: {date}",
+            f"base: {base}",
+            "files:",
+        ]
+    )
+    manifest.extend(manifest_files)
+    manifest.append("dev_files:")
+    manifest.extend(manifest_dev_files)
+
+    pathlib.Path(f"generated/{category}/{folder}").mkdir(parents=True, exist_ok=True)
+    with open(f"generated/{category}/{folder}/manifest.yaml", "w") as f:
+        f.write("\n".join(manifest) + "\n")
+
+
+def generate_manifests(category, config, filter_path=None):
+    is_version_folder = config.get("sort") != "normal"
+
+    # In case we expect subfolders, crawl into them before generating manifests
+    if config.get("subfolders") is not None:
+        _, folders = list_folder(category)
+        # Make sure we don't recurse a second time
+        old_subfolders = config["subfolders"]
+        config["subfolders"] = None
+
+        for folder in folders:
+            skip_write = filter_path and not filter_path.startswith(f"{category}/{folder}/")
+            if not skip_write:
+                generate_manifests(f"{category}/{folder}", config, filter_path=filter_path)
+
+        config["subfolders"] = old_subfolders
+        return
+
+    files, folders = list_folder(category, is_version_folder=is_version_folder)
+    for folder in folders:
+        skip_write = filter_path and not filter_path.startswith(f"{category}/{folder}/")
+
+        if not skip_write:
+            files, _ = list_folder(f"{category}/{folder}")
+            _generate_manifest(category, folder, files, config)

--- a/cdn/cdn_generator/version_sort.py
+++ b/cdn/cdn_generator/version_sort.py
@@ -1,0 +1,27 @@
+def version_sort(s):
+    """
+    Sort a list of versions based on the way OpenTTD versions the releases.
+
+    This is always one of the following:
+     - 1.2.3-alpha1
+     - 1.2.3-beta2
+     - 1.2.3-RC3
+     - 1.2.3
+
+    This function sorts this in that order (beta before RC before stable).
+    """
+    version, _, preversion = s.partition("-")
+
+    # This works because 'alpha' < 'beta' < 'rc' < 'stable'. It is a bit cheating.
+    preversion = preversion.lower()
+    if not preversion:
+        preversion = "stable"
+
+    # There are some versions like 0.4.0.1, that needs special attention.
+    # We solve it by making this [0, 4, 0, "stable1"], which sorts correctly.
+    versions = version.split(".")
+    if len(version) > 3:
+        preversion += str(versions[3:])
+        versions = versions[0:3]
+
+    return list(map(int, versions)) + [preversion]

--- a/cdn/config.yaml
+++ b/cdn/config.yaml
@@ -1,0 +1,25 @@
+folders:
+- name: catcodec-releases
+- name: grfcodec-releases
+- name: nforenum-releases
+- name: nosound-releases
+- name: opengfx-releases
+- name: openmsx-releases
+- name: opensfx-releases
+- name: openttd-releases
+- name: openttd-useful-releases
+- name: osie-releases
+
+- name: openttd-nightlies
+  subfolders: per-year
+  override-name: in-folder-name
+  sort: normal
+
+- name: openttd-pullrequests
+  subfolders: per-name
+  override-name: in-folder-name
+  sort: normal
+
+- name: grfcodec-nightlies
+  override-name: nightly
+  sort: normal

--- a/cdn/errors/404.html
+++ b/cdn/errors/404.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>404 - Not Found</title>
+  </head>
+  <body>
+    <main>
+      <h1>404 - Not Found</h1>
+    </main>
+  </body>
+</html>

--- a/cdn/requirements.base
+++ b/cdn/requirements.base
@@ -1,0 +1,3 @@
+boto3
+click
+PyYAML

--- a/cdn/requirements.txt
+++ b/cdn/requirements.txt
@@ -1,0 +1,10 @@
+boto3==1.11.9
+botocore==1.14.9
+Click==7.0
+docutils==0.15.2
+jmespath==0.9.4
+python-dateutil==2.8.1
+PyYAML==5.3
+s3transfer==0.3.2
+six==1.14.0
+urllib3==1.25.8


### PR DESCRIPTION
This includes:
 - index.html: an index file (as S3 / CloudFront / CloudFlare
               cannot do this for us)
 - folders.yaml: to be able to script walking the CDN
 - latest.yaml: a short summary for the latest release of a
                category
 - manifest.yaml: manifest file per release

This can be generated for everything, or only for a single (new)
release. The first is a rebuild, the second is for when a new
release is pushed to the CDN. In the second case the bare minimum
will be done to come to the same result as a full rebuild would
have done.

This requires read access to the S3 via the AWS API.
