### PR TITLE
Fix: openttd-pullrequests is renamed into openttd-branches

### DIFF
--- a/cdn/config.yaml
+++ b/cdn/config.yaml
@@ -15,7 +15,7 @@ folders:
   override-name: in-folder-name
   sort: normal
 
-- name: openttd-pullrequests
+- name: openttd-branches
   subfolders: per-name
   override-name: in-folder-name
   sort: normal


### PR DESCRIPTION
This because the OpenTTD release workflow now also allows to build
any branch, not only PRs.