### PR TITLE
Fix: awscliv2 need AWS_REGION, even for commands that are not bound to regions

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -74,3 +74,4 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/update-cdn.yml
+++ b/.github/workflows/update-cdn.yml
@@ -70,6 +70,7 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
 
     - name: Trigger 'publish website' (Staging)
       uses: peter-evans/repository-dispatch@v1


### PR DESCRIPTION
Without it, it will try to fetch this metadata from IMDS service,
which of course is not available on GitHub Actions (rightfully).

So we set the AWS_REGION, although it is never used.

---

This problem became clear now GHA switched to Ubuntu 20.04, which uses AWS CLI v2.