### PR TITLE
Fix: GitHub schedules are consistent late

### DIFF
--- a/.github/workflows/eints-to-git.yml
+++ b/.github/workflows/eints-to-git.yml
@@ -2,8 +2,8 @@ name: Eints to Git
 
 on:
   schedule:
-  - cron: '45 17 * * *'
-  - cron: '45 18 * * *'
+  - cron: '30 17 * * *'
+  - cron: '30 18 * * *'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
We depend that the GitHub Actions triggers within
15 minutes of the requested time, as otherwise
the 17:45 run will happen in 18:NN. This in result
means our TimeZone detection things it is the run
of 18:45, and makes the wrong choice.

Sadly, reality shows GitHub schedules workflows
often more than 15 minutes after the requested
time. So .. just run eints a bit earlier, hopefully
avoiding this issue. For sure it won't drift 30
minutes now would it?! (famous last words).