### PR TITLE
Fix: [Actions] queue publish-docs jobs so they are executed in order

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -9,6 +9,8 @@ on:
 #  - version: the version of the new release, e.g.: 20200101-master-g12345
 #  - folder: the folder in which the release is located openttd-nightlies/2020
 
+concurrency: docs
+
 jobs:
   publish_docs:
     name: Publish docs


### PR DESCRIPTION
This to prevent timing issues: if this job was executed twice in a relative short timespan, depending how GitHub schedules the runners, it could mean the last finished before the first, which results in the first overwriting older data over the newer. This hopefully prevents that for most cases.