### PR TITLE
Fix: [Actions] run eints / nightly export at 18:30 UTC / 19:00 UTC

### DIFF
--- a/.github/workflows/eints-to-git.yml
+++ b/.github/workflows/eints-to-git.yml
@@ -2,12 +2,8 @@ name: Eints to Git
 
 on:
   schedule:
-  - cron: '30 17 * * *'
   - cron: '30 18 * * *'
   workflow_dispatch:
-
-env:
-  SCHEDULE_HOUR: 19
 
 jobs:
   eints-to-git:
@@ -16,38 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Check for time in CE(S)T
-      if: github.event_name != 'workflow_dispatch'
-      id: cest_time
-      run: |
-        # GitHub Actions run in UTC. We want this export to be produced on
-        # 19:45 CE(S)T, which doesn't have a single UTC representation. So,
-        # we trigger this job twice. Once on CET and once on CEST. This step
-        # checks if it was 19:NN CE(S)T, and only allows one of the two to
-        # trigger the rest of this workflow.
-
-        HOUR=$(TZ=Europe/Amsterdam date +%H)
-        if [ "${HOUR}" = "${{ env.SCHEDULE_HOUR }}" ]; then
-          RUN_EINTS=1
-        else
-          RUN_EINTS=0
-        fi
-
-        echo "Current hour in CE(S)T: ${HOUR}"
-        echo "Scheduled hour: ${{ env.SCHEDULE_HOUR }}"
-        echo "Run eints to git: ${RUN_EINTS}"
-
-        echo "::set-output name=run_eints::${RUN_EINTS}"
-
     - name: Checkout
-      if: github.event_name == 'workflow_dispatch' || steps.cest_time.outputs.run_eints != '0'
       uses: actions/checkout@v2
       with:
         repository: OpenTTD/eints
         ref: openttd-github
 
     - name: Checkout OpenTTD-eints-test
-      if: github.event_name == 'workflow_dispatch' || steps.cest_time.outputs.run_eints != '0'
       uses: actions/checkout@v2
       with:
         repository: OpenTTD/eints-sandbox
@@ -55,7 +26,6 @@ jobs:
         token: ${{ secrets.EINTS_GITHUB_TOKEN }}
 
     - name: Checkout OpenTTD
-      if: github.event_name == 'workflow_dispatch' || steps.cest_time.outputs.run_eints != '0'
       uses: actions/checkout@v2
       with:
         repository: OpenTTD/OpenTTD
@@ -63,7 +33,6 @@ jobs:
         token: ${{ secrets.EINTS_GITHUB_TOKEN }}
 
     - name: Checkout OpenGFX
-      if: github.event_name == 'workflow_dispatch' || steps.cest_time.outputs.run_eints != '0'
       uses: actions/checkout@v2
       with:
         repository: OpenTTD/OpenGFX
@@ -71,7 +40,6 @@ jobs:
         token: ${{ secrets.EINTS_GITHUB_TOKEN }}
 
     - name: Checkout OpenSFX
-      if: github.event_name == 'workflow_dispatch' || steps.cest_time.outputs.run_eints != '0'
       uses: actions/checkout@v2
       with:
         repository: OpenTTD/OpenSFX
@@ -79,7 +47,6 @@ jobs:
         token: ${{ secrets.EINTS_GITHUB_TOKEN }}
 
     - name: Checkout OpenMSX
-      if: github.event_name == 'workflow_dispatch' || steps.cest_time.outputs.run_eints != '0'
       uses: actions/checkout@v2
       with:
         repository: OpenTTD/OpenMSX
@@ -87,7 +54,6 @@ jobs:
         token: ${{ secrets.EINTS_GITHUB_TOKEN }}
 
     - name: Checkout steam-data
-      if: github.event_name == 'workflow_dispatch' || steps.cest_time.outputs.run_eints != '0'
       uses: actions/checkout@v2
       with:
         repository: OpenTTD/steam-data
@@ -95,19 +61,16 @@ jobs:
         token: ${{ secrets.EINTS_GITHUB_TOKEN }}
 
     - name: Set up Python 3.8
-      if: github.event_name == 'workflow_dispatch' || steps.cest_time.outputs.run_eints != '0'
       uses: actions/setup-python@v1
       with:
         python-version: 3.8
 
     - name: Prepare git
-      if: github.event_name == 'workflow_dispatch' || steps.cest_time.outputs.run_eints != '0'
       run: |
         git config --global user.email "translators@openttd.org"
         git config --global user.name "translators"
 
     - name: Export staging
-      if: github.event_name == 'workflow_dispatch' || steps.cest_time.outputs.run_eints != '0'
       run: |
         cd scripts
 
@@ -121,7 +84,6 @@ jobs:
         TRANSLATORS_STAGING: ${{ secrets.TRANSLATORS_STAGING }}
 
     - name: Export production
-      if: github.event_name == 'workflow_dispatch' || steps.cest_time.outputs.run_eints != '0'
       run: |
         cd scripts
 

--- a/.github/workflows/openttd-nightly.yml
+++ b/.github/workflows/openttd-nightly.yml
@@ -2,12 +2,8 @@ name: OpenTTD nightly
 
 on:
   schedule:
-  - cron: '0 18 * * *'
   - cron: '0 19 * * *'
   workflow_dispatch:
-
-env:
-  SCHEDULE_HOUR: 20
 
 jobs:
   openttd-nightly:
@@ -16,31 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Check for time in CE(S)T
-      if: github.event_name != 'workflow_dispatch'
-      id: cest_time
-      run: |
-        # GitHub Actions run in UTC. We want the nightly to be produced on
-        # 20:00 CE(S)T, which doesn't have a single UTC representation. So,
-        # we trigger this job twice. Once on CET and once on CEST. This step
-        # checks if it was 20:NN CE(S)T, and only allows one of the two to
-        # trigger the rest of this workflow.
-
-        HOUR=$(TZ=Europe/Amsterdam date +%H)
-        if [ "${HOUR}" = "${{ env.SCHEDULE_HOUR }}" ]; then
-          BUILD_NIGHTLY=1
-        else
-          BUILD_NIGHTLY=0
-        fi
-
-        echo "Current hour in CE(S)T: ${HOUR}"
-        echo "Scheduled hour: ${{ env.SCHEDULE_HOUR }}"
-        echo "Build nightly: ${BUILD_NIGHTLY}"
-
-        echo "::set-output name=build_nightly::${BUILD_NIGHTLY}"
-
     - name: Check for new commit
-      if: github.event_name == 'workflow_dispatch' || steps.cest_time.outputs.build_nightly != '0'
       id: new_commit
       run: |
         LATEST_RELEASE=$(curl -s https://cdn.openttd.org/openttd-nightlies/latest.yaml | grep "\- version: " | cut -b 12-)


### PR DESCRIPTION
```
Basically, remove timezone support. On GitHub, it is utterly broken
as GitHub just executes schedules when-ever-it-feels-like it, with
drifts for over 30 minutes in same cases.
```