### PR TITLE
Fix: make sure versions are always in pair of three

### DIFF
--- a/cdn/cdn_generator/version_sort.py
+++ b/cdn/cdn_generator/version_sort.py
@@ -24,4 +24,8 @@ def version_sort(s):
         preversion += str(versions[3:])
         versions = versions[0:3]
 
+    # Ensure versions are always in pair of three.
+    if len(versions) < 3:
+        versions += ["0"] * (3 - len(versions))
+
     return list(map(int, versions)) + [preversion]


### PR DESCRIPTION
We release 13.2 these days, but recently also a 13.2.1. This meant that some entries had [13, 2], others [13, 2, 1], which sorting doesn't like. So add a 0 in the first case to make things right.