### PR TITLE
Change: [CI] Allow running update-cdn from the GitHub website

### DIFF
--- a/.github/workflows/update-cdn.yml
+++ b/.github/workflows/update-cdn.yml
@@ -4,6 +4,7 @@ on:
   repository_dispatch:
     types:
     - update-cdn
+  workflow_dispatch:
 
 # client_payload should contain:
 #  - version: the version of the new release, e.g.: 20200101-master-g12345


### PR DESCRIPTION
Running the workflow manually will not actually do anything useful at the moment; this is left for later PRs. But with this change the other PRs can be tested before merged.

GitHub has this annoying thing where you can only use workflow-dispatch if it is in the default branch; but once it is, you can select another branch to run the workflow-dispatch from that other branch. So this PR adds the ability to test those other branches before merging them.