### PR TITLE
Change: [CI] switch to GitHub App for triggering repository-dispatch events

### DIFF
--- a/.github/workflows/new-openttd-release.yml
+++ b/.github/workflows/new-openttd-release.yml
@@ -30,10 +30,18 @@ jobs:
           exit 1
         fi
 
+    - name: Generate access token
+      id: generate_token
+      uses: tibdex/github-app-token@v1
+      with:
+        app_id: ${{ secrets.DEPLOYMENT_APP_ID }}
+        private_key: ${{ secrets.DEPLOYMENT_APP_PRIVATE_KEY }}
+        repository: OpenTTD/workflows
+
     - name: Trigger 'update CDN'
       uses: peter-evans/repository-dispatch@v2
       with:
-        token: ${{ secrets.DEPLOYMENT_TOKEN }}
+        token: ${{ steps.generate_token.outputs.token }}
         repository: OpenTTD/workflows
         event-type: update-cdn
         client-payload: '{"version": "${{ github.event.client_payload.version }}", "folder": "${{ github.event.client_payload.folder }}"}'
@@ -43,7 +51,7 @@ jobs:
       name: Trigger 'publish docs'
       uses: peter-evans/repository-dispatch@v2
       with:
-        token: ${{ secrets.DEPLOYMENT_TOKEN }}
+        token: ${{ steps.generate_token.outputs.token }}
         repository: OpenTTD/workflows
         event-type: publish-docs
         client-payload: '{"version": "${{ github.event.client_payload.version }}", "folder": "${{ github.event.client_payload.folder }}"}'

--- a/.github/workflows/openttd-nightly.yml
+++ b/.github/workflows/openttd-nightly.yml
@@ -32,11 +32,20 @@ jobs:
 
         echo "build_nightly=${BUILD_NIGHTLY}" >> $GITHUB_OUTPUT
 
+    - name: Generate access token
+      if: steps.new_commit.outputs.build_nightly != '0'
+      id: generate_token
+      uses: tibdex/github-app-token@v1
+      with:
+        app_id: ${{ secrets.DEPLOYMENT_APP_ID }}
+        private_key: ${{ secrets.DEPLOYMENT_APP_PRIVATE_KEY }}
+        repository: OpenTTD/OpenTTD
+
     - name: Trigger 'Build nightly'
       if: steps.new_commit.outputs.build_nightly != '0'
       uses: peter-evans/repository-dispatch@v2
       with:
-        token: ${{ secrets.DEPLOYMENT_TOKEN }}
+        token: ${{ steps.generate_token.outputs.token }}
         repository: OpenTTD/OpenTTD
         event-type: Build nightly
         client-payload: '{"ref": "master"}'

--- a/.github/workflows/update-cdn.yml
+++ b/.github/workflows/update-cdn.yml
@@ -73,16 +73,24 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
 
+    - name: Generate access token
+      id: generate_token
+      uses: tibdex/github-app-token@v1
+      with:
+        app_id: ${{ secrets.DEPLOYMENT_APP_ID }}
+        private_key: ${{ secrets.DEPLOYMENT_APP_PRIVATE_KEY }}
+        repository: OpenTTD/website
+
     - name: Trigger 'publish website' (Staging)
       uses: peter-evans/repository-dispatch@v2
       with:
-        token: ${{ secrets.DEPLOYMENT_TOKEN }}
+        token: ${{ steps.generate_token.outputs.token }}
         repository: OpenTTD/website
         event-type: publish_main
 
     - name: Trigger 'publish website' (Production)
       uses: peter-evans/repository-dispatch@v2
       with:
-        token: ${{ secrets.DEPLOYMENT_TOKEN }}
+        token: ${{ steps.generate_token.outputs.token }}
         repository: OpenTTD/website
         event-type: publish_latest_tag


### PR DESCRIPTION
This means we no longer use the PAT of a user-account.