### PR TITLE
Change: Move nightly build to 5 AM UTC

### DIFF
--- a/.github/workflows/eints-sync.yml
+++ b/.github/workflows/eints-sync.yml
@@ -2,7 +2,7 @@ name: Eints sync
 
 on:
   schedule:
-  - cron: '30 18 * * *'
+  - cron: '30 4 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/openttd-nightly.yml
+++ b/.github/workflows/openttd-nightly.yml
@@ -2,7 +2,7 @@ name: OpenTTD nightly
 
 on:
   schedule:
-  - cron: '0 19 * * *'
+  - cron: '0 5 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Traditionally the OpenTTD nightly has been built around 20:00 CET/CEST, sometimes following CET/CEST, sometimes sticking to UTC.
I do not know about the original reasoning for this time, but I think it is inconvenient.

Requirements:
* The eints sync should run shortly before the nightly: 
    * Remove invalid translations, which cause compile warnings, and which PRs are not supposed to fix.
    * Include the latest translations.
* There should be no PR merge activity between eints sync and nightly build.
* If some friends want to play with the "latest" nightly, the meaning of "latest" should not change while more people join.

Assumptions:
* Developers merge between 8 AM CEST (= 6 UTC) and 10 PM CST (= 4 UTC).
* Players join in the evening: 6 PM AEDT (= 7 UTC) to 8 PM PST (= 4 UTC).

Result:
* The OpenTTD world is asleep from 4 UTC to 6 UTC.
* Do eints sync at 4:30 UTC.
* Build the nightly at 5:00 UTC.
* Hope things are ready at 6:00 UTC.