### PR TITLE
Fix: Detection of latest nightly ref

### DIFF
--- a/.github/workflows/openttd-nightly.yml
+++ b/.github/workflows/openttd-nightly.yml
@@ -17,9 +17,8 @@ jobs:
       run: |
         LATEST_RELEASE=$(curl -s https://cdn.openttd.org/openttd-nightlies/latest.yaml | grep "\- version: " | cut -b 12-)
         YEAR=$(echo "${LATEST_RELEASE}" | cut -b1-4)
-        LATEST_REF=$(curl -s https://cdn.openttd.org/openttd-nightlies/${YEAR}/${LATEST_RELEASE}/changelog.txt | head -n 1 | cut -d\  -f2)
-        CURRENT_REF=$(curl -s https://api.github.com/repos/OpenTTD/OpenTTD/branches/master | jq -r .commit.sha)
-
+        LATEST_REF=$(curl -s https://cdn.openttd.org/openttd-nightlies/${YEAR}/${LATEST_RELEASE}/changelog.md | head -n 3 | tail -n 1 | cut -d\  -f1)
+        CURRENT_REF=$(curl -s https://api.github.com/repos/OpenTTD/OpenTTD/branches/master | jq -r .commit.sha[0:$(expr length "${LATEST_REF}")])
         if [ "${LATEST_REF}" != "${CURRENT_REF}" ]; then
           BUILD_NIGHTLY=1
         else


### PR DESCRIPTION
Detection of latest nightly ref is broken since https://github.com/OpenTTD/OpenTTD/commit/f398a01c3ce4d3b6f9e2656c0160546f73f11f13 (introduction of the new changelog format) and https://github.com/OpenTTD/OpenTTD/commit/ae7bd04de863558f4c1ad77a2a233107b8f15631 (actually build using the new changelog format)
The current output of the workflow is:
```
Latest nightly ref: found
Current ref of master: 10c159a79f35adb25a92f9aabd94f077aa87fc09
Build nightly: 1
```
While it used to be:
```
Latest nightly ref: 10c159a79f35adb25a92f9aabd94f077aa87fc09
Current ref of master: 10c159a79f35adb25a92f9aabd94f077aa87fc09
Build nightly: 0
```
This then triggers useless builds which fail to upload to CDN.


Properly detect latest nightly ref.
Since the new changelog format doesn't contain the full commit sha, cut the current ref to the same length.
Output is now:
```
Latest nightly ref: 10c159a79f
Current ref of master: 10c159a79f
Build nightly: 0
```