### PR TITLE
Feature: detect the name of the changelog file and add it to the manifest

### DIFF
--- a/cdn/cdn_generator/cleanup.py
+++ b/cdn/cdn_generator/cleanup.py
@@ -20,7 +20,6 @@ def _cleanup_directory(folder, keep_source, do_delete):
                 continue
             # As this folder won't be empty, keep the files that indicate what this folder is about too.
             if file in (
-                "changelog.txt",
                 "index.html",
                 "manifest.yaml",
                 "README.md",
@@ -28,6 +27,8 @@ def _cleanup_directory(folder, keep_source, do_delete):
                 "README.txt",
                 "released.txt",
             ):
+                continue
+            if file.lower().startswith("changelog"):
                 continue
 
         fullname = f"{folder}/{file}"

--- a/cdn/cdn_generator/manifest_yaml.py
+++ b/cdn/cdn_generator/manifest_yaml.py
@@ -32,7 +32,11 @@ def _generate_manifest(category, folder, files, config):
     manifest_files = []
     manifest_dev_files = []
 
+    changelog = None
     for id, size in files.items():
+        if id.lower().startswith("changelog"):
+            changelog = id
+
         if id.endswith((".html", ".md", ".txt", ".yaml", ".md5sum", ".sha1sum", ".sha256sum")):
             continue
 
@@ -65,9 +69,11 @@ def _generate_manifest(category, folder, files, config):
             f"version: {folder}",
             f"date: {date}",
             f"base: {base}",
-            "files:",
         ]
     )
+    if changelog:
+        manifest.append(f"changelog: {changelog}")
+    manifest.append("files:")
     manifest.extend(manifest_files)
     manifest.append("dev_files:")
     manifest.extend(manifest_dev_files)


### PR DESCRIPTION
The website tries to do funky logic to detect the right changelog filename, and it fails.

Instead, just put it in the metadata.